### PR TITLE
start project as 'run as java-application'

### DIFF
--- a/src/main/java/com/nouhoun/springboot/jwt/integration/SpringbootJwtApplication.java
+++ b/src/main/java/com/nouhoun/springboot/jwt/integration/SpringbootJwtApplication.java
@@ -4,6 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@Import({SecurityConfig.class,
+	ResourceServerConfig.class,
+	DatasourceConfig.class,
+	AuthorizationServerConfig.class,
+	AdditionalWebConfig.class
+})
 public class SpringbootJwtApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
Added `@Import()` to easily start the application without deploying a jar or war file to tomcat. Spring boot provided a very efficient way to start an application as a java-application